### PR TITLE
Revert "Approval for Production deployment"

### DIFF
--- a/config/application-ns/tanzu-accuweather-app/delivery.yml
+++ b/config/application-ns/tanzu-accuweather-app/delivery.yml
@@ -25,7 +25,7 @@ spec:
         carto.run/workload-name: tanzu-accuweather-app
     spec:
       containers:
-      - image: buildservice.azurecr.io/clstrappsrepo/tanzu-accuweather-app-application-ns@sha256:e3e828be54727a936794595cb1cbcd5063b63361220418d90aaa19699cf47f11
+      - image: buildservice.azurecr.io/clstrappsrepo/tanzu-accuweather-app-application-ns@sha256:3a36e41097d8ebabad245d90dd10c68e296d2cf7c6de4bb9fae933247e8988f4
         name: workload
         resources: {}
         securityContext:


### PR DESCRIPTION
Reverts PradeepLoganathan/tap-gitops#10- 
Reverting the previous deployment as business indicated that market research confirmed black is not ideal.